### PR TITLE
DFPROTO-107: adding rabi block writes to RTIO

### DIFF
--- a/artiq/firmware/libriverlane/rabi.rs
+++ b/artiq/firmware/libriverlane/rabi.rs
@@ -1,8 +1,76 @@
-use csr;
 
-pub fn get_next_cmd() -> u32 {
-    unsafe {
-        csr::rabi::rabi_cntr0_write(0xffffffff);
-        csr::rabi::rabi_cntr0_read()
+    use csr;
+    //use board_misoc::csr;
+    use core::ptr::{read_volatile, write_volatile};
+
+
+    pub const RTIO_O_STATUS_WAIT:                      u8 = 1;
+    pub const RTIO_O_STATUS_UNDERFLOW:                 u8 = 2;
+    pub const RTIO_O_STATUS_DESTINATION_UNREACHABLE:   u8 = 4;
+    pub const RTIO_I_STATUS_WAIT_EVENT:                u8 = 1;
+    pub const RTIO_I_STATUS_OVERFLOW:                  u8 = 2;
+    pub const RTIO_I_STATUS_WAIT_STATUS:               u8 = 4;
+    pub const RTIO_I_STATUS_DESTINATION_UNREACHABLE:   u8 = 8;
+
+    // writing the LSB of o_data (offset=0) triggers the RTIO write
+    #[inline(always)]
+    pub unsafe fn rtio_o_data_write(offset: usize, data: u32) {
+        write_volatile(
+            csr::rtio::O_DATA_ADDR.offset((csr::rtio::O_DATA_SIZE - 1 - offset) as isize),
+            data);
     }
-}
+
+    #[inline(always)]
+    pub unsafe fn rtio_i_data_read(offset: usize) -> u32 {
+        read_volatile(
+            csr::rtio::I_DATA_ADDR.offset((csr::rtio::I_DATA_SIZE - 1 - offset) as isize))
+    }
+
+    pub extern fn get_counter() -> i64 {
+        unsafe {
+            csr::rtio::counter_update_write(1);
+            csr::rtio::counter_read() as i64
+        }
+    }
+    
+    #[inline(never)]
+    pub fn process_exceptional_status(status: u8) -> &'static str {
+        unsafe {
+
+        if status & RTIO_O_STATUS_WAIT != 0 {
+            while csr::rtio::o_status_read() & RTIO_O_STATUS_WAIT != 0 {}
+        }
+        if status & RTIO_O_STATUS_UNDERFLOW != 0 {
+            return "RTIO underflow"; 
+        }
+        if status & RTIO_O_STATUS_DESTINATION_UNREACHABLE != 0 {
+            return "RTIO destination unreachable";
+        }
+        return "RTIO_OK";
+        }   
+    }
+
+
+
+    pub fn get_next_cmd() -> Option<u32> {
+        unsafe {
+            csr::rabi::rabi_cntr0_write(0xffffffff);
+            let cmd = csr::rabi::rabi_cntr0_read();
+            if cmd == 0 {
+                None
+            } else {
+                Some(cmd)
+            }
+            
+        }   
+    }
+
+    pub fn send_cmd_to_rtio(cmd: u32) -> u8{
+        unsafe {
+            csr::rtio::target_write(0 as u32);
+            // writing target clears o_data
+            rtio_o_data_write(0, cmd as _);
+            csr::rtio::o_status_read()
+        }
+    }
+

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -137,7 +137,6 @@ fn startup() {
         smoltcp::phy::EthernetTracer::new(net_device, net_trace_fn)
     };
 
-    info!("Net_device completed");
     let neighbor_cache =
         smoltcp::iface::NeighborCache::new(alloc::btree_map::BTreeMap::new());
     let net_addresses = net_settings::get_adresses();

--- a/artiq/firmware/runtime/main.rs
+++ b/artiq/firmware/runtime/main.rs
@@ -72,6 +72,7 @@ fn grabber_thread(io: sched::Io) {
 }
 
 fn setup_log_levels() {
+    info!("about to read_str log_level -> ");
     match config::read_str("log_level", |r| r.map(|s| s.parse())) {
         Ok(Ok(log_level_filter)) => {
             info!("log level set to {} by `log_level` config key",
@@ -98,9 +99,6 @@ fn startup() {
     info!("ARTIQ runtime starting...");
     info!("software ident {}", csr::CONFIG_IDENTIFIER_STR);
     info!("gateware ident {}", ident::read(&mut [0; 64]));
-
-    #[cfg[has_rabi]]
-    info!("Riverlane: Rabi block - first command retrieved is: {:x}", rabi::get_next_cmd()); 
 
     setup_log_levels();
     #[cfg(has_i2c)]
@@ -139,6 +137,7 @@ fn startup() {
         smoltcp::phy::EthernetTracer::new(net_device, net_trace_fn)
     };
 
+    info!("Net_device completed");
     let neighbor_cache =
         smoltcp::iface::NeighborCache::new(alloc::btree_map::BTreeMap::new());
     let net_addresses = net_settings::get_adresses();
@@ -168,7 +167,7 @@ fn startup() {
                        .finalize()
         }
     };
-
+    
     #[cfg(has_drtio)]
     let drtio_routing_table = urc::Urc::new(RefCell::new(
         drtio_routing::config_routing_table(csr::DRTIO.len())));
@@ -180,7 +179,7 @@ fn startup() {
     #[cfg(has_drtio_routing)]
     drtio_routing::interconnect_disable_all();
     let aux_mutex = sched::Mutex::new();
-
+    
     let mut scheduler = sched::Scheduler::new();
     let io = scheduler.io();
 
@@ -192,7 +191,9 @@ fn startup() {
         let drtio_routing_table = drtio_routing_table.clone();
         let up_destinations = up_destinations.clone();
         io.spawn(16384, move |io| { session::thread(io, &aux_mutex, &drtio_routing_table, &up_destinations) });
+        print!("session completed");
     }
+
     #[cfg(any(has_rtio_moninj, has_drtio))]
     {
         let aux_mutex = aux_mutex.clone();
@@ -204,7 +205,24 @@ fn startup() {
 
     #[cfg(has_grabber)]
     io.spawn(4096, grabber_thread);
+   
+    
+    #[cfg(has_rabi)]
+    {
+        use core::ptr::{read_volatile, write_volatile};
+        while let Some(cmd) = rabi::get_next_cmd() {
+            info!("Riverlane: Rabi block - new command retrieved is: {:x}", cmd);
+            let retv = rabi::send_cmd_to_rtio(cmd);
+            info!("Riverlane: Rabi block - command was sent to RTIO!");
+            if (retv != 0){
+                info!("Riverlane: Rabi block - RTIO returned {:x} that indicates {}", retv, rabi::process_exceptional_status(retv));
+            }
 
+        }  
+    }
+
+
+    info!("Setting up the EthernetStatics");
     let mut net_stats = ethmac::EthernetStatistics::new();
     loop {
         scheduler.run();


### PR DESCRIPTION
The main changes are about:
- Allowing Flash operations even without L2 (I don't see why you shouldn't be allowed to do it)
- Changes to the lib_riverlane to write to the RTIO memory space directly. 
Don't even merge there are still too many new-lines that don't need to make to master, just give me please a general thumbs up or down! I will then polish and do another pull request!